### PR TITLE
Remove 2.9 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Doctrine DBAL
 
-| [Master][Master] | [2.9][2.9] | [Develop][develop] |
-|:----------------:|:----------:|:------------------:|
-| [![Build status][Master image]][Master] | [![Build status][2.9 image]][2.9] | [![Build status][develop image]][develop] |
-| [![Build Status][ContinuousPHP image]][ContinuousPHP] | [![Build Status][ContinuousPHP 2.9 image]][ContinuousPHP] | [![Build Status][ContinuousPHP develop image]][ContinuousPHP] |
-| [![Code Coverage][Coverage image]][Scrutinizer Master] | [![Code Coverage][Coverage 2.9 image]][Scrutinizer 2.9] | [![Code Coverage][Coverage develop image]][Scrutinizer develop] |
-| [![Code Quality][Quality image]][Scrutinizer Master] | [![Code Quality][Quality 2.9 image]][Scrutinizer 2.9] | [![Code Quality][Quality develop image]][Scrutinizer develop] |
-| [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.9 image]][AppVeyor 2.9] | [![AppVeyor][AppVeyor develop image]][AppVeyor develop] |
+| [Master][Master] | [2.10][2.10] | [Develop][develop] |
+|:----------------:|:------------:|:------------------:|
+| [![Build status][Master image]][Master] | [![Build status][2.10 image]][2.10] | [![Build status][develop image]][develop] |
+| [![Build Status][ContinuousPHP image]][ContinuousPHP] | [![Build Status][ContinuousPHP 2.10 image]][ContinuousPHP] | [![Build Status][ContinuousPHP develop image]][ContinuousPHP] |
+| [![Code Coverage][Coverage image]][Scrutinizer Master] | [![Code Coverage][Coverage 2.10 image]][Scrutinizer 2.10] | [![Code Coverage][Coverage develop image]][Scrutinizer develop] |
+| [![Code Quality][Quality image]][Scrutinizer Master] | [![Code Quality][Quality 2.10 image]][Scrutinizer 2.10] | [![Code Quality][Quality develop image]][Scrutinizer develop] |
+| [![AppVeyor][AppVeyor master image]][AppVeyor master] | [![AppVeyor][AppVeyor 2.10 image]][AppVeyor 2.10] | [![AppVeyor][AppVeyor develop image]][AppVeyor develop] |
 
 Powerful database abstraction layer with many features for database schema introspection, schema management and PDO abstraction.
 
@@ -26,14 +26,14 @@ Powerful database abstraction layer with many features for database schema intro
   [AppVeyor master image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/master?svg=true
   [ContinuousPHP]: https://continuousphp.com/git-hub/doctrine/dbal
 
-  [2.9 image]: https://img.shields.io/travis/doctrine/dbal/2.9.svg?style=flat-square
-  [Coverage 2.9 image]: https://img.shields.io/scrutinizer/coverage/g/doctrine/dbal/2.9.svg?style=flat-square
-  [Quality 2.9 image]: https://img.shields.io/scrutinizer/g/doctrine/dbal/2.9.svg?style=flat-square
-  [ContinuousPHP 2.9 image]: https://img.shields.io/continuousphp/git-hub/doctrine/dbal/2.9.svg?style=flat-square
-  [2.9]: https://github.com/doctrine/dbal/tree/2.9
-  [Scrutinizer 2.9]: https://scrutinizer-ci.com/g/doctrine/dbal/?branch=2.9
-  [AppVeyor 2.9]: https://ci.appveyor.com/project/doctrine/dbal/branch/2.9
-  [AppVeyor 2.9 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/2.9?svg=true
+  [2.10 image]: https://img.shields.io/travis/doctrine/dbal/2.10.svg?style=flat-square
+  [Coverage 2.10 image]: https://img.shields.io/scrutinizer/coverage/g/doctrine/dbal/2.10.svg?style=flat-square
+  [Quality 2.10 image]: https://img.shields.io/scrutinizer/g/doctrine/dbal/2.10.svg?style=flat-square
+  [ContinuousPHP 2.10 image]: https://img.shields.io/continuousphp/git-hub/doctrine/dbal/2.10.svg?style=flat-square
+  [2.10]: https://github.com/doctrine/dbal/tree/2.10
+  [Scrutinizer 2.10]: https://scrutinizer-ci.com/g/doctrine/dbal/?branch=2.10
+  [AppVeyor 2.10]: https://ci.appveyor.com/project/doctrine/dbal/branch/2.10
+  [AppVeyor 2.10 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/2.10?svg=true
 
   [develop]: https://github.com/doctrine/dbal/tree/develop
   [develop image]: https://img.shields.io/travis/doctrine/dbal/develop.svg?style=flat-square


### PR DESCRIPTION
2.10 was released a while back. README.md should reflect the current stable version.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | documentation
| BC Break     | no
| Fixed issues | none

#### Summary

<!-- Provide a summary of your change. -->
